### PR TITLE
Refactor the training entrypoints for DeepProtein 2.0.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,4 +1,4 @@
-<p align="center"><img src="figs/deeppurpose_pp_logo.png" alt="DeepProtein Logo" width="400px" /></p>
+<p align="center"><img src="docs/source/_static/deepprotein_logo.png" alt="PsiProtein Logo" width="400px" /></p>
 
 ---
 

--- a/train/CRISPR.py
+++ b/train/CRISPR.py
@@ -1,59 +1,18 @@
-import os
-import sys
-import argparse
-import wandb
-
-module_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-if module_path not in sys.path:
-    sys.path.append(module_path)
-
-from DeepProtein.load_dataset import *
+from cli_common import build_config, build_parser, initialize_run
+from DeepProtein.load_dataset import load_single_dataset
 import DeepProtein.ProteinPred as models
 
-
-def parse_args():
-    parser = argparse.ArgumentParser(description="Protein Prediction with DeepProtein")
-    parser.add_argument('--target_encoding', type=str, default='CNN', help='Encoding method for target proteins')
-    parser.add_argument('--seed', type=int, default=42, help='Random seed for reproducibility')
-    parser.add_argument('--wandb_proj', type=str, default='your_project_name', help='wandb project name')
-    parser.add_argument('--lr', type=float, default=0.0001, help='0.0001/0.00001')
-    parser.add_argument('--epochs', type=int, default=100, help='50/100')
-    parser.add_argument('--compute_pos_enc', type=bool, default=False, help='compute position encoding')
-    parser.add_argument('--batch_size', type=int, default=32, help='batch size')
-
-
-    return parser.parse_args()
-
-
 if __name__ == "__main__":
+    args = build_parser("Protein Prediction with DeepProtein").parse_args()
+    path = initialize_run(args, f"CRISPR + {args.target_encoding}")
+    train, val, test = load_single_dataset("CRISPR", path, args.target_encoding)
 
-    args = parse_args()
-    target_encoding = args.target_encoding
-    wandb_project = args.wandb_proj
-    lr = args.lr
-    epochs = args.epochs
-    compute_pos = args.compute_pos_enc
-    batch_size = args.batch_size
-
-    job_name = f"CRISPR + {target_encoding}"
-    wandb.init(project=wandb_project, name=job_name)
-    wandb.config.update(args)
-
-    path = os.getcwd()
-
-    train, val, test = load_single_dataset("CRISPR", path, target_encoding)
-
-    config = generate_config(target_encoding=target_encoding,
-                             cls_hidden_dims=[512],
-                             train_epoch=epochs,
-                             LR=lr,
-                             batch_size=batch_size,
-                             )
-
-    config['binary'] = False
-    config['multi'] = False
-    torch.manual_seed(args.seed)
+    config = build_config(
+        args,
+        cls_hidden_dims=[512],
+        extra_config={'binary': False, 'multi': False},
+    )
     model = models.model_initialize(**config)
-    model.train(train, val, test, compute_pos_enc = compute_pos)
+    model.train(train, val, test, compute_pos_enc=args.compute_pos_enc)
 
 

--- a/train/IEDB.py
+++ b/train/IEDB.py
@@ -1,57 +1,22 @@
-import os
-import sys
-import argparse
-import wandb
-
-module_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-if module_path not in sys.path:
-    sys.path.append(module_path)
-
-from DeepProtein.load_dataset import *
+from cli_common import build_config, build_parser, initialize_run
+from DeepProtein.load_dataset import load_residue_dataset
 import DeepProtein.TokenPred as models
 
-def parse_args():
-    parser = argparse.ArgumentParser(description="Protein Prediction with DeepProtein")
-    parser.add_argument('--target_encoding', type=str, default='Token_CNN', help='Encoding method for target proteins')
-    parser.add_argument('--seed', type=int, default=42, help='Random seed for reproducibility')
-    parser.add_argument('--wandb_proj', type=str, default='your_project_name', help='wandb project name')
-    parser.add_argument('--lr', type=float, default=0.0001, help='0.0001/0.00001')
-    parser.add_argument('--epochs', type=int, default=2, help='50/100')
-    parser.add_argument('--compute_pos_enc', type=bool, default=False, help='compute position encoding')
-    parser.add_argument('--batch_size', type=int, default=32, help='batch size')
-
-
-    return parser.parse_args()
-
-
 if __name__ == "__main__":
+    args = build_parser(
+        "Protein Prediction with DeepProtein",
+        default_target_encoding='Token_CNN',
+        default_epochs=2,
+    ).parse_args()
+    initialize_run(args, f"IEDB + {args.target_encoding}")
+    train, val, test = load_residue_dataset("IEDB", None, args.target_encoding)
 
-    args = parse_args()
-    target_encoding = args.target_encoding
-    wandb_project = args.wandb_proj
-    lr = args.lr
-    epochs = args.epochs
-    compute_pos = args.compute_pos_enc
-    batch_size = args.batch_size
-
-    job_name = f"IEDB + {target_encoding}"
-    wandb.init(project=wandb_project, name=job_name)
-    wandb.config.update(args)
-
-    train, val, test = load_residue_dataset("IEDB", None, target_encoding)
-
-    config = generate_config(target_encoding=target_encoding,
-                             cls_hidden_dims=[1024, 1024],
-                             train_epoch=epochs,
-                             LR=lr,
-                             batch_size=batch_size ,
-                             )
-    config['multi'] = False
-    config['binary'] = True
-    config['token'] = True
-    config['in_channels'] = 24
-    torch.manual_seed(args.seed)
+    config = build_config(
+        args,
+        cls_hidden_dims=[1024, 1024],
+        extra_config={'multi': False, 'binary': True, 'token': True, 'in_channels': 24},
+    )
     model = models.model_initialize(**config)
-    model.train(train, val, test, batch_size=batch_size)
+    model.train(train, val, test, batch_size=args.batch_size)
 
 

--- a/train/PDB.py
+++ b/train/PDB.py
@@ -1,59 +1,22 @@
-import os
-import sys
-import argparse
-import wandb
-
-module_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-if module_path not in sys.path:
-    sys.path.append(module_path)
-
-from DeepProtein.load_dataset import *
+from cli_common import build_config, build_parser, initialize_run
+from DeepProtein.load_dataset import load_residue_dataset
 import DeepProtein.TokenPred as models
 
-def parse_args():
-    parser = argparse.ArgumentParser(description="Protein Prediction with DeepProtein")
-    parser.add_argument('--target_encoding', type=str, default='Token_CNN', help='Encoding method for target proteins')
-    parser.add_argument('--seed', type=int, default=42, help='Random seed for reproducibility')
-    parser.add_argument('--wandb_proj', type=str, default='your_project_name', help='wandb project name')
-    parser.add_argument('--lr', type=float, default=0.0001, help='0.0001/0.00001')
-    parser.add_argument('--epochs', type=int, default=2, help='50/100')
-    parser.add_argument('--compute_pos_enc', type=bool, default=False, help='compute position encoding')
-    parser.add_argument('--batch_size', type=int, default=32, help='batch size')
-
-
-    return parser.parse_args()
-
-
 if __name__ == "__main__":
+    args = build_parser(
+        "Protein Prediction with DeepProtein",
+        default_target_encoding='Token_CNN',
+        default_epochs=2,
+    ).parse_args()
+    path = initialize_run(args, f"PDB + {args.target_encoding}")
+    train, val, test = load_residue_dataset("PDB", path, args.target_encoding)
 
-    args = parse_args()
-    target_encoding = args.target_encoding
-    wandb_project = args.wandb_proj
-    lr = args.lr
-    epochs = args.epochs
-    compute_pos = args.compute_pos_enc
-    batch_size = args.batch_size
-
-    job_name = f"PDB + {target_encoding}"
-    wandb.init(project=wandb_project, name=job_name)
-    wandb.config.update(args)
-
-    path = os.getcwd()
-
-    train, val, test = load_residue_dataset("PDB", path, target_encoding)
-
-    config = generate_config(target_encoding=target_encoding,
-                             cls_hidden_dims=[1024, 1024],
-                             train_epoch=epochs,
-                             LR=lr,
-                             batch_size=batch_size ,
-                             )
-    config['multi'] = False
-    config['binary'] = True
-    config['token'] = True
-    config['in_channels'] = 20
-    torch.manual_seed(args.seed)
+    config = build_config(
+        args,
+        cls_hidden_dims=[1024, 1024],
+        extra_config={'multi': False, 'binary': True, 'token': True, 'in_channels': 20},
+    )
     model = models.model_initialize(**config)
-    model.train(train, val, test, batch_size=batch_size)
+    model.train(train, val, test, batch_size=args.batch_size)
 
 

--- a/train/SAbDab_Chen.py
+++ b/train/SAbDab_Chen.py
@@ -1,60 +1,18 @@
-import os
-import sys
-import argparse
-import torch
-import wandb
-
-module_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-if module_path not in sys.path:
-    sys.path.append(module_path)
-
-from DeepProtein.load_dataset import *
+from cli_common import build_config, build_parser, initialize_run
+from DeepProtein.load_dataset import load_pair_dataset
 import DeepProtein.PPI as models
 
-
-def parse_args():
-    parser = argparse.ArgumentParser(description="Protein Prediction with DeepProtein")
-    parser.add_argument('--target_encoding', type=str, default='CNN', help='Encoding method for target proteins')
-    parser.add_argument('--seed', type=int, default=42, help='Random seed for reproducibility')
-    parser.add_argument('--wandb_proj', type=str, default='your_project_name', help='wandb project name')
-    parser.add_argument('--lr', type=float, default=0.0001, help='0.0001/0.00001')
-    parser.add_argument('--epochs', type=int, default=100, help='50/100')
-    parser.add_argument('--compute_pos_enc', type=bool, default=False, help='compute position encoding')
-    parser.add_argument('--batch_size', type=int, default=32, help='batch size')
-
-
-    return parser.parse_args()
-
-
 if __name__ == "__main__":
+    args = build_parser("Protein Prediction with DeepProtein").parse_args()
+    path = initialize_run(args, f"SAbDab_Chen + {args.target_encoding}")
+    train, val, test = load_pair_dataset("SAbDab_Chen", path, args.target_encoding)
 
-    args = parse_args()
-    target_encoding = args.target_encoding
-    wandb_project = args.wandb_proj
-    lr = args.lr
-    epochs = args.epochs
-    compute_pos = args.compute_pos_enc
-    batch_size = args.batch_size
-
-    job_name = f"SAbDab_Chen + {target_encoding}"
-    wandb.init(project=wandb_project, name=job_name)
-    wandb.config.update(args)
-
-    path = os.getcwd()
-
-    train, val, test = load_pair_dataset("SAbDab_Chen", path, target_encoding)
-
-    config = generate_config(target_encoding=target_encoding,
-                             cls_hidden_dims=[512],
-                             train_epoch=epochs,
-                             LR=lr,
-                             batch_size=batch_size,
-                             )
-
-    config['binary'] = False
-    config['multi'] = False
-    torch.manual_seed(args.seed)
+    config = build_config(
+        args,
+        cls_hidden_dims=[512],
+        extra_config={'binary': False, 'multi': False},
+    )
     model = models.model_initialize(**config)
-    model.train(train, val, test, compute_pos_enc = compute_pos)
+    model.train(train, val, test, compute_pos_enc=args.compute_pos_enc)
 
 

--- a/train/SAbDab_Liberis.py
+++ b/train/SAbDab_Liberis.py
@@ -1,59 +1,22 @@
-import os
-import sys
-import argparse
-import wandb
-
-module_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-if module_path not in sys.path:
-    sys.path.append(module_path)
-
-from DeepProtein.load_dataset import *
+from cli_common import build_config, build_parser, initialize_run
+from DeepProtein.load_dataset import load_residue_dataset
 import DeepProtein.TokenPred as models
 
-def parse_args():
-    parser = argparse.ArgumentParser(description="Protein Prediction with DeepProtein")
-    parser.add_argument('--target_encoding', type=str, default='Token_Transformer', help='Encoding method for target proteins')
-    parser.add_argument('--seed', type=int, default=42, help='Random seed for reproducibility')
-    parser.add_argument('--wandb_proj', type=str, default='your_project_name', help='wandb project name')
-    parser.add_argument('--lr', type=float, default=0.0001, help='0.0001/0.00001')
-    parser.add_argument('--epochs', type=int, default=1, help='50/100')
-    parser.add_argument('--compute_pos_enc', type=bool, default=False, help='compute position encoding')
-    parser.add_argument('--batch_size', type=int, default=32, help='batch size')
-
-
-    return parser.parse_args()
-
-
 if __name__ == "__main__":
+    args = build_parser(
+        "Protein Prediction with DeepProtein",
+        default_target_encoding='Token_Transformer',
+        default_epochs=1,
+    ).parse_args()
+    path = initialize_run(args, f"SAbDab_Liberis + {args.target_encoding}")
+    train, val, test = load_residue_dataset("SAbDab_Liberis", path, args.target_encoding)
 
-    args = parse_args()
-    target_encoding = args.target_encoding
-    wandb_project = args.wandb_proj
-    lr = args.lr
-    epochs = args.epochs
-    compute_pos = args.compute_pos_enc
-    batch_size = args.batch_size
-
-    job_name = f"SAbDab_Liberis + {target_encoding}"
-    wandb.init(project=wandb_project, name=job_name)
-    wandb.config.update(args)
-
-    path = os.getcwd()
-
-    train, val, test = load_residue_dataset("SAbDab_Liberis", path, target_encoding)
-
-    config = generate_config(target_encoding=target_encoding,
-                             cls_hidden_dims=[1024, 1024],
-                             train_epoch=epochs,
-                             LR=lr,
-                             batch_size=batch_size,
-                             )
-    config['multi'] = False
-    config['binary'] = True
-    config['token'] = True
-    config['in_channels'] = 20
-    torch.manual_seed(args.seed)
+    config = build_config(
+        args,
+        cls_hidden_dims=[1024, 1024],
+        extra_config={'multi': False, 'binary': True, 'token': True, 'in_channels': 20},
+    )
     model = models.model_initialize(**config)
-    model.train(train, val, test, batch_size=batch_size)
+    model.train(train, val, test, batch_size=args.batch_size)
 
 

--- a/train/TAP.py
+++ b/train/TAP.py
@@ -1,60 +1,18 @@
-import os
-import sys
-import argparse
-import torch
-import wandb
-
-module_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-if module_path not in sys.path:
-    sys.path.append(module_path)
-
-from DeepProtein.load_dataset import *
+from cli_common import build_config, build_parser, initialize_run
+from DeepProtein.load_dataset import load_pair_dataset
 import DeepProtein.PPI as models
 
-
-def parse_args():
-    parser = argparse.ArgumentParser(description="Protein Prediction with DeepProtein")
-    parser.add_argument('--target_encoding', type=str, default='CNN', help='Encoding method for target proteins')
-    parser.add_argument('--seed', type=int, default=42, help='Random seed for reproducibility')
-    parser.add_argument('--wandb_proj', type=str, default='your_project_name', help='wandb project name')
-    parser.add_argument('--lr', type=float, default=0.0001, help='0.0001/0.00001')
-    parser.add_argument('--epochs', type=int, default=100, help='50/100')
-    parser.add_argument('--compute_pos_enc', type=bool, default=False, help='compute position encoding')
-    parser.add_argument('--batch_size', type=int, default=32, help='batch size')
-
-
-    return parser.parse_args()
-
-
 if __name__ == "__main__":
+    args = build_parser("Protein Prediction with DeepProtein").parse_args()
+    path = initialize_run(args, f"TAP + {args.target_encoding}")
+    train, val, test = load_pair_dataset("TAP", path, args.target_encoding)
 
-    args = parse_args()
-    target_encoding = args.target_encoding
-    wandb_project = args.wandb_proj
-    lr = args.lr
-    epochs = args.epochs
-    compute_pos = args.compute_pos_enc
-    batch_size = args.batch_size
-
-    job_name = f"TAP + {target_encoding}"
-    wandb.init(project=wandb_project, name=job_name)
-    wandb.config.update(args)
-
-    path = os.getcwd()
-
-    train, val, test = load_pair_dataset("TAP", path, target_encoding)
-
-    config = generate_config(target_encoding=target_encoding,
-                             cls_hidden_dims=[512],
-                             train_epoch=epochs,
-                             LR=lr,
-                             batch_size=batch_size,
-                             )
-
-    config['binary'] = False
-    config['multi'] = False
-    torch.manual_seed(args.seed)
+    config = build_config(
+        args,
+        cls_hidden_dims=[512],
+        extra_config={'binary': False, 'multi': False},
+    )
     model = models.model_initialize(**config)
-    model.train(train, val, test, compute_pos_enc = compute_pos)
+    model.train(train, val, test, compute_pos_enc=args.compute_pos_enc)
 
 

--- a/train/beta.py
+++ b/train/beta.py
@@ -1,56 +1,16 @@
-import os
-import sys
-import argparse
-import wandb
-
-module_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-if module_path not in sys.path:
-    sys.path.append(module_path)
-
-from DeepProtein.load_dataset import *
+from cli_common import build_config, build_parser, initialize_run
+from DeepProtein.load_dataset import load_single_dataset
 import DeepProtein.ProteinPred as models
 
-def parse_args():
-    parser = argparse.ArgumentParser(description="Protein Prediction with DeepProtein")
-    parser.add_argument('--target_encoding', type=str, default='CNN', help='Encoding method for target proteins')
-    parser.add_argument('--seed', type=int, default=42, help='Random seed for reproducibility')
-    parser.add_argument('--wandb_proj', type=str, default='your_project_name', help='wandb project name')
-    parser.add_argument('--lr', type=float, default=0.0001, help='0.0001/0.00001')
-    parser.add_argument('--epochs', type=int, default=100, help='50/100')
-    parser.add_argument('--compute_pos_enc', type=bool, default=False, help='compute position encoding')
-    parser.add_argument('--batch_size', type=int, default=32, help='batch size')
-
-    return parser.parse_args()
-
-
 if __name__ == "__main__":
-
-    args = parse_args()
-    target_encoding = args.target_encoding
-    wandb_project = args.wandb_proj
-    lr = args.lr
-    epochs = args.epochs
-    compute_pos = args.compute_pos_enc
-    batch_size = args.batch_size
-
-    job_name = f"Beta + {target_encoding}"
-    wandb.init(project=wandb_project, name=job_name)
-    wandb.config.update(args)
-
-    path = os.getcwd()
+    args = build_parser("Protein Prediction with DeepProtein").parse_args()
+    path = initialize_run(args, f"Beta + {args.target_encoding}")
 
     #  Test on Beta lactamase
-    train, val, test = load_single_dataset("Beta", path, target_encoding)
+    train, val, test = load_single_dataset("Beta", path, args.target_encoding)
 
-    config = generate_config(target_encoding=target_encoding,
-                             cls_hidden_dims=[1024, 1024],
-                             train_epoch=epochs,
-                             LR=lr,
-                             batch_size=batch_size ,
-                             )
-    config['multi'] = False
-    torch.manual_seed(args.seed)
+    config = build_config(args, cls_hidden_dims=[1024, 1024], extra_config={'multi': False})
     model = models.model_initialize(**config)
-    model.train(train, val, test, compute_pos_enc = compute_pos)
+    model.train(train, val, test, compute_pos_enc=args.compute_pos_enc)
 
 

--- a/train/cli_common.py
+++ b/train/cli_common.py
@@ -1,0 +1,59 @@
+import argparse
+import os
+import sys
+
+import torch
+import wandb
+
+
+module_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+if module_path not in sys.path:
+    sys.path.append(module_path)
+
+from DeepProtein.utils import generate_config
+
+
+def str2bool(value):
+    if isinstance(value, bool):
+        return value
+
+    normalized = value.lower()
+    if normalized in {'true', 't', '1', 'yes', 'y'}:
+        return True
+    if normalized in {'false', 'f', '0', 'no', 'n'}:
+        return False
+    raise argparse.ArgumentTypeError(f"Expected a boolean value, got: {value}")
+
+
+def build_parser(description, default_target_encoding='CNN', default_epochs=100):
+    parser = argparse.ArgumentParser(description=description)
+    parser.add_argument('--target_encoding', type=str, default=default_target_encoding,
+                        help='Encoding method for target proteins')
+    parser.add_argument('--seed', type=int, default=42, help='Random seed for reproducibility')
+    parser.add_argument('--wandb_proj', type=str, default='your_project_name', help='wandb project name')
+    parser.add_argument('--lr', type=float, default=0.0001, help='0.0001/0.00001')
+    parser.add_argument('--epochs', type=int, default=default_epochs, help='50/100')
+    parser.add_argument('--compute_pos_enc', type=str2bool, default=False,
+                        help='compute position encoding')
+    parser.add_argument('--batch_size', type=int, default=32, help='batch size')
+    return parser
+
+
+def initialize_run(args, job_name):
+    wandb.init(project=args.wandb_proj, name=job_name)
+    wandb.config.update(vars(args))
+    torch.manual_seed(args.seed)
+    return os.getcwd()
+
+
+def build_config(args, cls_hidden_dims, extra_config=None):
+    config = generate_config(
+        target_encoding=args.target_encoding,
+        cls_hidden_dims=cls_hidden_dims,
+        train_epoch=args.epochs,
+        LR=args.lr,
+        batch_size=args.batch_size,
+    )
+    if extra_config:
+        config.update(extra_config)
+    return config

--- a/train/fluroscence.py
+++ b/train/fluroscence.py
@@ -1,56 +1,14 @@
-import os
-import sys
-import argparse
-import wandb
-
-module_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-if module_path not in sys.path:
-    sys.path.append(module_path)
-
-from DeepProtein.load_dataset import *
+from cli_common import build_config, build_parser, initialize_run
+from DeepProtein.load_dataset import load_single_dataset
 import DeepProtein.ProteinPred as models
 
-
-def parse_args():
-    parser = argparse.ArgumentParser(description="Protein Prediction with DeepProtein")
-    parser.add_argument('--target_encoding', type=str, default='CNN', help='Encoding method for target proteins')
-    parser.add_argument('--seed', type=int, default=42, help='Random seed for reproducibility')
-    parser.add_argument('--wandb_proj', type=str, default='your_project_name', help='wandb project name')
-    parser.add_argument('--lr', type=float, default=0.0001, help='0.0001/0.00001')
-    parser.add_argument('--epochs', type=int, default=100, help='50/100')
-    parser.add_argument('--compute_pos_enc', type=bool, default=False, help='compute position encoding')
-    parser.add_argument('--batch_size', type=int, default=32, help='batch size')
-
-
-    return parser.parse_args()
-
-
 if __name__ == "__main__":
+    args = build_parser("Protein Prediction with DeepProtein").parse_args()
+    path = initialize_run(args, f"Fluorescence + {args.target_encoding}")
+    train, val, test = load_single_dataset("Fluorescence", path, args.target_encoding)
 
-    args = parse_args()
-    target_encoding = args.target_encoding
-    wandb_project = args.wandb_proj
-    lr = args.lr
-    epochs = args.epochs
-    compute_pos = args.compute_pos_enc
-    batch_size = args.batch_size
-
-    job_name = f"Fluorescence + {target_encoding}"
-    wandb.init(project=wandb_project, name=job_name)
-    wandb.config.update(args)
-
-    path = os.getcwd()
-    train, val, test = load_single_dataset("Fluorescence", path, target_encoding)
-
-    config = generate_config(target_encoding=target_encoding,
-                             cls_hidden_dims=[1024, 1024],
-                             train_epoch=epochs,
-                             LR=lr,
-                             batch_size=batch_size ,
-                             )
-    config['multi'] = False
-    torch.manual_seed(args.seed)
+    config = build_config(args, cls_hidden_dims=[1024, 1024], extra_config={'multi': False})
     model = models.model_initialize(**config)
-    model.train(train, val, test, compute_pos_enc = compute_pos)
+    model.train(train, val, test, compute_pos_enc=args.compute_pos_enc)
 
 

--- a/train/fold.py
+++ b/train/fold.py
@@ -1,61 +1,20 @@
-import os
-import sys
-import argparse
-import wandb
-
-
-module_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-if module_path not in sys.path:
-    sys.path.append(module_path)
-
-from DeepProtein.load_dataset import *
+from cli_common import build_config, build_parser, initialize_run
+from DeepProtein.load_dataset import load_single_dataset
 import DeepProtein.ProteinPred as models
 
-
-def parse_args():
-    parser = argparse.ArgumentParser(description="Protein Prediction with DeepProtein")
-    parser.add_argument('--target_encoding', type=str, default='CNN', help='Encoding method for target proteins')
-    parser.add_argument('--seed', type=int, default=42, help='Random seed for reproducibility')
-    parser.add_argument('--wandb_proj', type=str, default='your_project_name', help='wandb project name')
-    parser.add_argument('--lr', type=float, default=0.0001, help='0.0001/0.00001')
-    parser.add_argument('--epochs', type=int, default=100, help='50/100')
-    parser.add_argument('--compute_pos_enc', type=bool, default=False, help='compute position encoding')
-    parser.add_argument('--batch_size', type=int, default=32, help='batch size')
-
-    return parser.parse_args()
-
-
 if __name__ == "__main__":
-
-    args = parse_args()
-    target_encoding = args.target_encoding
-    wandb_project = args.wandb_proj
-    lr = args.lr
-    epochs = args.epochs
-    compute_pos = args.compute_pos_enc
-    batch_size = args.batch_size
-
-    job_name = f"Fold + {target_encoding}"
-    wandb.init(project=wandb_project, name=job_name)
-    wandb.config.update(args)
-
-    path = os.getcwd()
+    args = build_parser("Protein Prediction with DeepProtein").parse_args()
+    path = initialize_run(args, f"Fold + {args.target_encoding}")
 
     #  Test on Fold
-    train, val, test = load_single_dataset("Fold", path, target_encoding)
+    train, val, test = load_single_dataset("Fold", path, args.target_encoding)
 
-    config = generate_config(target_encoding=target_encoding,
-                             cls_hidden_dims=[1024, 1024],
-                             train_epoch=epochs,
-                             LR=lr,
-                             batch_size=batch_size ,
-                             )
-    config['multi'] = True
-    config['binary'] = False
-    config['classes'] = 1195
-
-    torch.manual_seed(args.seed)
+    config = build_config(
+        args,
+        cls_hidden_dims=[1024, 1024],
+        extra_config={'multi': True, 'binary': False, 'classes': 1195},
+    )
     model = models.model_initialize(**config)
-    model.train(train, val, test, compute_pos_enc = compute_pos)
+    model.train(train, val, test, compute_pos_enc=args.compute_pos_enc)
 
 

--- a/train/human_ppi.py
+++ b/train/human_ppi.py
@@ -1,54 +1,11 @@
-import os
-import sys
-import argparse
-import torch
-import wandb
-
-module_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-if module_path not in sys.path:
-    sys.path.append(module_path)
-
-from DeepProtein.load_dataset import *
+from cli_common import build_config, build_parser, initialize_run
+from DeepProtein.load_dataset import load_pair_dataset
 import DeepProtein.PPI as models
 
-def parse_args():
-    parser = argparse.ArgumentParser(description="PPI Prediction with `DeepProtein`")
-    parser.add_argument('--target_encoding', type=str, default='CNN', help='Encoding method for target proteins')
-    parser.add_argument('--seed', type=int, default=42, help='Random seed for reproducibility')
-    parser.add_argument('--wandb_proj', type=str, default='your_project_name', help='wandb project name')
-    parser.add_argument('--lr', type=float, default=0.0001, help='0.0001/0.00001')
-    parser.add_argument('--epochs', type=int, default=100, help='50/100')
-    parser.add_argument('--compute_pos_enc', type=bool, default=False, help='compute position encoding')
-    parser.add_argument('--batch_size', type=int, default=32, help='batch size')
-    return parser.parse_args()
-
-
 if __name__ == '__main__':
-
-    args = parse_args()
-    target_encoding = args.target_encoding
-    wandb_project = args.wandb_proj
-    lr = args.lr
-    epochs = args.epochs
-    compute_pos = args.compute_pos_enc
-    batch_size = args.batch_size
-
-    job_name = f"Human_PPI + {target_encoding}"
-    wandb.init(project=wandb_project, name=job_name)
-    wandb.config.update(args)
-
-    path = os.getcwd()
-
-    train, val, test = load_pair_dataset("Human_PPI", path, target_encoding)
-    #
-    config = generate_config(target_encoding = target_encoding,
-                             cls_hidden_dims = [512],
-                             train_epoch = epochs,
-                             LR = lr,
-                             batch_size = batch_size,
-                            )
-    config['multi'] = False
-    config['binary'] = True
-    torch.manual_seed(args.seed)
+    args = build_parser("PPI Prediction with `DeepProtein`").parse_args()
+    path = initialize_run(args, f"Human_PPI + {args.target_encoding}")
+    train, val, test = load_pair_dataset("Human_PPI", path, args.target_encoding)
+    config = build_config(args, cls_hidden_dims=[512], extra_config={'multi': False, 'binary': True})
     model = models.model_initialize(**config)
-    model.train(train, val, test, compute_pos_enc = compute_pos)
+    model.train(train, val, test, compute_pos_enc=args.compute_pos_enc)

--- a/train/ppi_affinity.py
+++ b/train/ppi_affinity.py
@@ -1,53 +1,11 @@
-import os
-import sys
-import argparse
-import torch
-import wandb
-
-module_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-if module_path not in sys.path:
-    sys.path.append(module_path)
-
-from DeepProtein.load_dataset import *
+from cli_common import build_config, build_parser, initialize_run
+from DeepProtein.load_dataset import load_pair_dataset
 import DeepProtein.PPI as models
 
-def parse_args():
-    parser = argparse.ArgumentParser(description="PPI Prediction with `DeepProtein`")
-    parser.add_argument('--target_encoding', type=str, default='CNN', help='Encoding method for target proteins')
-    parser.add_argument('--seed', type=int, default=42, help='Random seed for reproducibility')
-    parser.add_argument('--wandb_proj', type=str, default='your_project_name', help='wandb project name')
-    parser.add_argument('--lr', type=float, default=0.0001, help='0.0001/0.00001')
-    parser.add_argument('--epochs', type=int, default=100, help='50/100')
-    parser.add_argument('--compute_pos_enc', type=bool, default=False, help='compute position encoding')
-    parser.add_argument('--batch_size', type=int, default=32, help='batch size')
-    return parser.parse_args()
-
-
 if __name__ == '__main__':
-
-    args = parse_args()
-    target_encoding = args.target_encoding
-    wandb_project = args.wandb_proj
-    lr = args.lr
-    epochs = args.epochs
-    compute_pos = args.compute_pos_enc
-    batch_size = args.batch_size
-
-    job_name = f"PPI_Affinity + {target_encoding}"
-    wandb.init(project=wandb_project, name=job_name)
-    wandb.config.update(args)
-
-    path = os.getcwd()
-
-    train, val, test = load_pair_dataset("PPI_Affinity", path, target_encoding)
-    #
-    config = generate_config(target_encoding = target_encoding,
-                             cls_hidden_dims = [512],
-                             train_epoch = epochs,
-                             LR = lr,
-                             batch_size = batch_size,
-                            )
-    config['multi'] = False
-    torch.manual_seed(args.seed)
+    args = build_parser("PPI Prediction with `DeepProtein`").parse_args()
+    path = initialize_run(args, f"PPI_Affinity + {args.target_encoding}")
+    train, val, test = load_pair_dataset("PPI_Affinity", path, args.target_encoding)
+    config = build_config(args, cls_hidden_dims=[512], extra_config={'multi': False})
     model = models.model_initialize(**config)
-    model.train(train, val, test, compute_pos_enc = compute_pos)
+    model.train(train, val, test, compute_pos_enc=args.compute_pos_enc)

--- a/train/secondary.py
+++ b/train/secondary.py
@@ -1,61 +1,24 @@
-import os
-import sys
-import argparse
-import wandb
-
-
-module_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-if module_path not in sys.path:
-    sys.path.append(module_path)
-
-from DeepProtein.load_dataset import *
+from cli_common import build_config, build_parser, initialize_run
+from DeepProtein.load_dataset import load_residue_dataset
 import DeepProtein.TokenPred as models
 
-def parse_args():
-    parser = argparse.ArgumentParser(description="Protein Prediction with DeepProtein")
-    parser.add_argument('--target_encoding', type=str, default='CNN', help='Encoding method for target proteins')
-    parser.add_argument('--seed', type=int, default=42, help='Random seed for reproducibility')
-    parser.add_argument('--wandb_proj', type=str, default='your_project_name', help='wandb project name')
-    parser.add_argument('--lr', type=float, default=0.0001, help='0.0001/0.00001')
-    parser.add_argument('--epochs', type=int, default=100, help='50/100')
-    parser.add_argument('--compute_pos_enc', type=bool, default=False, help='compute position encoding')
-    parser.add_argument('--batch_size', type=int, default=32, help='batch size')
-
-    return parser.parse_args()
-
-
 if __name__ == "__main__":
+    args = build_parser("Protein Prediction with DeepProtein").parse_args()
+    path = initialize_run(args, f"Secondary + {args.target_encoding}")
+    train, val, test = load_residue_dataset("Secondary", path, args.target_encoding)
 
-    args = parse_args()
-    target_encoding = args.target_encoding
-    wandb_project = args.wandb_proj
-    lr = args.lr
-    epochs = args.epochs
-    compute_pos = args.compute_pos_enc
-    batch_size = args.batch_size
-
-    job_name = f"Secondary + {target_encoding}"
-    wandb.init(project=wandb_project, name=job_name)
-    wandb.config.update(args)
-
-    path = os.getcwd()
-
-    train, val, test = load_residue_dataset("Secondary", path, target_encoding)
-
-    config = generate_config(target_encoding=target_encoding,
-                             cls_hidden_dims=[1024, 1024],
-                             train_epoch=epochs,
-                             LR=lr,
-                             batch_size=batch_size ,
-                             )
-    config['multi'] = True
-    config['token'] = True
-    config['binary'] = False
-    config['classes'] = 3
-    config['in_channels'] = 21
-    torch.manual_seed(args.seed)
+    config = build_config(
+        args,
+        cls_hidden_dims=[1024, 1024],
+        extra_config={
+            'multi': True,
+            'token': True,
+            'binary': False,
+            'classes': 3,
+            'in_channels': 21,
+        },
+    )
     model = models.model_initialize(**config)
-
-    model.train(train, val, test, batch_size=batch_size)
+    model.train(train, val, test, batch_size=args.batch_size)
 
 

--- a/train/solubility.py
+++ b/train/solubility.py
@@ -1,60 +1,18 @@
-import os
-import sys
-import argparse
-import wandb
-
-module_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-if module_path not in sys.path:
-    sys.path.append(module_path)
-
-from DeepProtein.load_dataset import *
+from cli_common import build_config, build_parser, initialize_run
+from DeepProtein.load_dataset import load_single_dataset
 import DeepProtein.ProteinPred as models
 
-
-def parse_args():
-    parser = argparse.ArgumentParser(description="Protein Prediction with DeepProtein")
-    parser.add_argument('--target_encoding', type=str, default='CNN', help='Encoding method for target proteins')
-    parser.add_argument('--seed', type=int, default=42, help='Random seed for reproducibility')
-    parser.add_argument('--wandb_proj', type=str, default='your_project_name', help='wandb project name')
-    parser.add_argument('--lr', type=float, default=0.0001, help='0.0001/0.00001')
-    parser.add_argument('--epochs', type=int, default=100, help='50/100')
-    parser.add_argument('--compute_pos_enc', type=bool, default=False, help='compute position encoding')
-    parser.add_argument('--batch_size', type=int, default=32, help='batch size')
-
-
-    return parser.parse_args()
-
-
 if __name__ == "__main__":
+    args = build_parser("Protein Prediction with DeepProtein").parse_args()
+    path = initialize_run(args, f"Solubility + {args.target_encoding}")
+    train, val, test = load_single_dataset("Solubility", path, args.target_encoding)
 
-    args = parse_args()
-    target_encoding = args.target_encoding
-    wandb_project = args.wandb_proj
-    lr = args.lr
-    epochs = args.epochs
-    compute_pos = args.compute_pos_enc
-    batch_size = args.batch_size
-
-    job_name = f"Solubility + {target_encoding}"
-    wandb.init(project=wandb_project, name=job_name)
-    wandb.config.update(args)
-
-    path = os.getcwd()
-
-    train, val, test = load_single_dataset("Solubility", path, target_encoding)
-
-    config = generate_config(target_encoding=target_encoding,
-                             cls_hidden_dims=[1024, 1024],
-                             train_epoch=epochs,
-                             LR=lr,
-                             batch_size=batch_size,
-                             )
-    
-    config['binary'] = True
-    config['multi'] = False
-
-    torch.manual_seed(args.seed)
+    config = build_config(
+        args,
+        cls_hidden_dims=[1024, 1024],
+        extra_config={'binary': True, 'multi': False},
+    )
     model = models.model_initialize(**config)
-    model.train(train, val, test, compute_pos_enc = compute_pos)
+    model.train(train, val, test, compute_pos_enc=args.compute_pos_enc)
 
 

--- a/train/stability.py
+++ b/train/stability.py
@@ -1,55 +1,14 @@
-import os
-import sys
-import argparse
-import wandb
-
-module_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-if module_path not in sys.path:
-    sys.path.append(module_path)
-
-from DeepProtein.load_dataset import *
+from cli_common import build_config, build_parser, initialize_run
+from DeepProtein.load_dataset import load_single_dataset
 import DeepProtein.ProteinPred as models
 
-def parse_args():
-    parser = argparse.ArgumentParser(description="Protein Prediction with DeepProtein")
-    parser.add_argument('--target_encoding', type=str, default='CNN', help='Encoding method for target proteins')
-    parser.add_argument('--seed', type=int, default=42, help='Random seed for reproducibility')
-    parser.add_argument('--wandb_proj', type=str, default='your_project_name', help='wandb project name')
-    parser.add_argument('--lr', type=float, default=0.0001, help='0.0001/0.00001')
-    parser.add_argument('--epochs', type=int, default=100, help='50/100')
-    parser.add_argument('--compute_pos_enc', type=bool, default=False, help='compute position encoding')
-    parser.add_argument('--batch_size', type=int, default=32, help='batch size')
-
-    return parser.parse_args()
-
-
 if __name__ == "__main__":
-
-    args = parse_args()
-    target_encoding = args.target_encoding
-    wandb_project = args.wandb_proj
-    lr = args.lr
-    epochs = args.epochs
-    compute_pos = args.compute_pos_enc
-    batch_size = args.batch_size
-    job_name = f"Stability + {target_encoding}"
-    wandb.init(project=wandb_project, name=job_name)
-    wandb.config.update(args)
-
-    path = os.getcwd()
+    args = build_parser("Protein Prediction with DeepProtein").parse_args()
+    path = initialize_run(args, f"Stability + {args.target_encoding}")
     #  Test on Stability Dataset
-    train, val, test = load_single_dataset("Stability", path, target_encoding)
-
-    config = generate_config(target_encoding=target_encoding,
-                             cls_hidden_dims=[1024, 1024],
-                             train_epoch=epochs,
-                             LR=lr,
-                             batch_size=batch_size,
-                             )
-
-    config['multi'] = False
-    torch.manual_seed(args.seed)
+    train, val, test = load_single_dataset("Stability", path, args.target_encoding)
+    config = build_config(args, cls_hidden_dims=[1024, 1024], extra_config={'multi': False})
     model = models.model_initialize(**config)
-    model.train(train, val, test, compute_pos_enc = compute_pos)
+    model.train(train, val, test, compute_pos_enc=args.compute_pos_enc)
 
 

--- a/train/subcellular.py
+++ b/train/subcellular.py
@@ -1,61 +1,18 @@
-import os
-import sys
-import argparse
-import wandb
-
-module_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-if module_path not in sys.path:
-    sys.path.append(module_path)
-
-from DeepProtein.load_dataset import *
+from cli_common import build_config, build_parser, initialize_run
+from DeepProtein.load_dataset import load_single_dataset
 import DeepProtein.ProteinPred as models
 
-
-def parse_args():
-    parser = argparse.ArgumentParser(description="Protein Prediction with `DeepProtein`")
-    parser.add_argument('--target_encoding', type=str, default='CNN', help='Encoding method for target proteins')
-    parser.add_argument('--seed', type=int, default=42, help='Random seed for reproducibility')
-    parser.add_argument('--wandb_proj', type=str, default='your_project_name', help='wandb project name')
-    parser.add_argument('--lr', type=float, default=0.0001, help='0.0001/0.00001')
-    parser.add_argument('--epochs', type=int, default=100, help='50/100')
-    parser.add_argument('--compute_pos_enc', type=bool, default=False, help='compute position encoding')
-    parser.add_argument('--batch_size', type=int, default=32, help='batch size')
-
-
-    return parser.parse_args()
-
-
 if __name__ == "__main__":
+    args = build_parser("Protein Prediction with `DeepProtein`").parse_args()
+    path = initialize_run(args, f"SubCellular + {args.target_encoding}")
+    train, val, test = load_single_dataset("SubCellular", path, args.target_encoding)
 
-    args = parse_args()
-    target_encoding = args.target_encoding
-    wandb_project = args.wandb_proj
-    lr = args.lr
-    epochs = args.epochs
-    compute_pos = args.compute_pos_enc
-    batch_size = args.batch_size
-
-    job_name = f"SubCellular + {target_encoding}"
-    wandb.init(project=wandb_project, name=job_name)
-    wandb.config.update(args)
-
-    path = os.getcwd()
-
-    train, val, test = load_single_dataset("SubCellular", path, target_encoding)
-
-    config = generate_config(target_encoding=target_encoding,
-                             cls_hidden_dims=[1024, 1024],
-                             train_epoch=epochs,
-                             LR=lr,
-                             batch_size=batch_size,
-                             )
-    
-    config['binary'] = False
-    config['multi'] = True
-    config['classes'] = 10
-
-    torch.manual_seed(args.seed)
+    config = build_config(
+        args,
+        cls_hidden_dims=[1024, 1024],
+        extra_config={'binary': False, 'multi': True, 'classes': 10},
+    )
     model = models.model_initialize(**config)
-    model.train(train, val, test, compute_pos_enc = compute_pos)
+    model.train(train, val, test, compute_pos_enc=args.compute_pos_enc)
 
 

--- a/train/subcellular_binary.py
+++ b/train/subcellular_binary.py
@@ -1,61 +1,18 @@
-import os
-import sys
-import argparse
-
-import wandb
-
-module_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-if module_path not in sys.path:
-    sys.path.append(module_path)
-
-from DeepProtein.load_dataset import *
+from cli_common import build_config, build_parser, initialize_run
+from DeepProtein.load_dataset import load_single_dataset
 import DeepProtein.ProteinPred as models
 
-
-def parse_args():
-    parser = argparse.ArgumentParser(description="Protein Prediction with `DeepProtein`")
-    parser.add_argument('--target_encoding', type=str, default='CNN', help='Encoding method for target proteins')
-    parser.add_argument('--seed', type=int, default=42, help='Random seed for reproducibility')
-    parser.add_argument('--wandb_proj', type=str, default='your_project_name', help='wandb project name')
-    parser.add_argument('--lr', type=float, default=0.0001, help='0.0001/0.00001')
-    parser.add_argument('--epochs', type=int, default=100, help='50/100')
-    parser.add_argument('--compute_pos_enc', type=bool, default=False, help='compute position encoding')
-    parser.add_argument('--batch_size', type=int, default=32, help='batch size')
-
-
-    return parser.parse_args()
-
-
 if __name__ == "__main__":
+    args = build_parser("Protein Prediction with `DeepProtein`").parse_args()
+    path = initialize_run(args, f"SubCellular Binary + {args.target_encoding}")
+    train, val, test = load_single_dataset("SubCellular_Binary", path, args.target_encoding)
 
-    args = parse_args()
-    target_encoding = args.target_encoding
-    wandb_project = args.wandb_proj
-    lr = args.lr
-    epochs = args.epochs
-    compute_pos = args.compute_pos_enc
-    batch_size = args.batch_size
-
-    job_name = f"SubCellular Binary + {target_encoding}"
-    wandb.init(project=wandb_project, name=job_name)
-    wandb.config.update(args)
-
-    path = os.getcwd()
-
-    train, val, test = load_single_dataset("SubCellular_Binary", path, target_encoding)
-
-    config = generate_config(target_encoding=target_encoding,
-                             cls_hidden_dims=[1024, 1024],
-                             train_epoch=epochs,
-                             LR=lr,
-                             batch_size=batch_size,
-                             )
-    
-    config['binary'] = True
-    config['multi'] = False
-
-    torch.manual_seed(args.seed)
+    config = build_config(
+        args,
+        cls_hidden_dims=[1024, 1024],
+        extra_config={'binary': True, 'multi': False},
+    )
     model = models.model_initialize(**config)
-    model.train(train, val, test, compute_pos_enc = compute_pos)
+    model.train(train, val, test, compute_pos_enc=args.compute_pos_enc)
 
 

--- a/train/yeast_ppi.py
+++ b/train/yeast_ppi.py
@@ -1,54 +1,11 @@
-import os
-import sys
-import argparse
-import torch
-import wandb
-
-module_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-if module_path not in sys.path:
-    sys.path.append(module_path)
-
-from DeepProtein.load_dataset import *
+from cli_common import build_config, build_parser, initialize_run
+from DeepProtein.load_dataset import load_pair_dataset
 import DeepProtein.PPI as models
 
-def parse_args():
-    parser = argparse.ArgumentParser(description="PPI Prediction with `DeepProtein`")
-    parser.add_argument('--target_encoding', type=str, default='CNN', help='Encoding method for target proteins')
-    parser.add_argument('--seed', type=int, default=42, help='Random seed for reproducibility')
-    parser.add_argument('--wandb_proj', type=str, default='your_project_name', help='wandb project name')
-    parser.add_argument('--lr', type=float, default=0.0001, help='0.0001/0.00001')
-    parser.add_argument('--epochs', type=int, default=100, help='50/100')
-    parser.add_argument('--compute_pos_enc', type=bool, default=False, help='compute position encoding')
-    parser.add_argument('--batch_size', type=int, default=32, help='batch size')
-    return parser.parse_args()
-
-
 if __name__ == '__main__':
-
-    args = parse_args()
-    target_encoding = args.target_encoding
-    wandb_project = args.wandb_proj
-    lr = args.lr
-    epochs = args.epochs
-    compute_pos = args.compute_pos_enc
-    batch_size = args.batch_size
-
-    job_name = f"Yeast_PPI + {target_encoding}"
-    wandb.init(project=wandb_project, name=job_name)
-    wandb.config.update(args)
-
-    path = os.getcwd()
-
-    train, val, test = load_pair_dataset("Yeast_PPI", path, target_encoding)
-    #
-    config = generate_config(target_encoding = target_encoding,
-                             cls_hidden_dims = [512],
-                             train_epoch = epochs,
-                             LR = lr,
-                             batch_size = batch_size,
-                            )
-    config['multi'] = False
-    config['binary'] = True
-    torch.manual_seed(args.seed)
+    args = build_parser("PPI Prediction with `DeepProtein`").parse_args()
+    path = initialize_run(args, f"Yeast_PPI + {args.target_encoding}")
+    train, val, test = load_pair_dataset("Yeast_PPI", path, args.target_encoding)
+    config = build_config(args, cls_hidden_dims=[512], extra_config={'multi': False, 'binary': True})
     model = models.model_initialize(**config)
-    model.train(train, val, test, compute_pos_enc = compute_pos)
+    model.train(train, val, test, compute_pos_enc=args.compute_pos_enc)


### PR DESCRIPTION
Extract the shared CLI bootstrap into a common helper so the top-level train scripts stop duplicating argument parsing, wandb setup, seeding, and config wiring, and point the README logo directly at the new PsiProtein asset.

Made-with: Cursor